### PR TITLE
Add ENFORCE_HTTPS environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,7 @@ ENV OFFLOAD_TO_HOST=localhost \
     PROXY_CONNECT_TIMEOUT="60s" \
     PROXY_SEND_TIMEOUT="60s" \
     PROXY_READ_TIMEOUT="60s" \
+    ENFORCE_HTTPS="true" \
     PROMETHEUS_METRICS_PORT="9101" \
     DEFAULT_BUCKETS="{0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 7.5, 10, 15, 20, 30, 60, 120}" \
     NGINX_CONF_TMPL_PATH="/tmpl/nginx.conf.tmpl" \


### PR DESCRIPTION
Add ENFORCE_HTTPS environment variable, if set to false the default port 80 server proxy_pass to the host instead of redirecting the the port 443.