### PR TITLE
Add application/hal+json in gzip_types

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -51,6 +51,7 @@ http {
         application/atom+xml
         application/javascript
         application/json
+        application/hal+json
         application/rss+xml
         application/vnd.ms-fontobject
         application/x-font-ttf


### PR DESCRIPTION
In order to enable compression in application/hal+json responses I added this content-type in gzip-types.