### PR TITLE
Add application/hal+json in gzip-types

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -38,7 +38,7 @@ http {
   gzip_comp_level 5;
   gzip_min_length 1000;
   gzip_proxied any;
-  gzip_types application/atom+xml application/javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component text/xml  application/xml+rss text/javascript;
+  gzip_types application/atom+xml application/javascript application/json application/hal+json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component text/xml  application/xml+rss text/javascript;
   gzip_vary on;
 
   # request sizes


### PR DESCRIPTION
In order to enable compression in application/hal+json responses I added this content-type in gzip-types.